### PR TITLE
Use OfflineAudioContext when decoding audio files

### DIFF
--- a/MediaFilesAPI/wwwroot/mediaFiles.js
+++ b/MediaFilesAPI/wwwroot/mediaFiles.js
@@ -35,7 +35,7 @@ export async function decodeAudioFile(name) {
     const fileBytes = await file.arrayBuffer();
 
     // Decode and extract the audio samples
-    const audioBuffer = await new AudioContext().decodeAudioData(fileBytes);
+    const audioBuffer = await new OfflineAudioContext(2, 44100, 44100).decodeAudioData(fileBytes);
     return new Uint8Array(audioBuffer.getChannelData(0).buffer);
 }
 


### PR DESCRIPTION
AudioContext may require autoplay permissions to work and will open the user's audio output device to play samples + kick off a mixer, while OfflineAudioContext won't have those problems