### PR TITLE
Update .NET references to 7.0.0

### DIFF
--- a/AudioBrowser/AudioBrowser.csproj
+++ b/AudioBrowser/AudioBrowser.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid" Version="0.1.0-alpha.22351.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0-rtm.22477.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0-rtm.22477.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" PrivateAssets="all" />
     <PackageReference Include="NeoSmart.PrettySize" Version="3.1.1" />
   </ItemGroup>
 

--- a/MediaFilesAPI/MediaFilesAPI.csproj
+++ b/MediaFilesAPI/MediaFilesAPI.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0-rtm.22477.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Now that .NET 7 has been released, the current references trigger a warning when compiling.